### PR TITLE
FetchContent compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.out
 .svn
 build
+cmake-build-*/
 bin
 lib
 cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,10 @@ else()
     target_link_libraries(${PROJECT_NAME} setupapi)
 endif()
 # Make the headers available to any targets linking the library (e.g., serial_example, test, via FetchContent).
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(${PROJECT_NAME} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
 
 if(${CXX_SERIAL_EXAMPLES})
     ## Example executable using cxx-serial

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,10 @@ endif()
 ## Sources
 set(serial_SRCS
     src/serial.cc
-    include/serial/serial.h
-    include/serial/v8stdint.h
+)
+set(serial_HDRS
+    ${CMAKE_CURRENT_LIST_DIR}/include/serial/serial.h
+    ${CMAKE_CURRENT_LIST_DIR}/include/serial/v8stdint.h
 )
 if(APPLE)
     # If OSX
@@ -27,7 +29,11 @@ else()
 endif()
 
 ## Add serial library
-add_library(${PROJECT_NAME} ${serial_SRCS})
+add_library(${PROJECT_NAME})
+target_sources(${PROJECT_NAME}
+    PRIVATE ${serial_SRCS}
+    PUBLIC ${serial_HDRS}
+)
 if(APPLE)
     target_link_libraries(${PROJECT_NAME} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY})
 elseif(UNIX)
@@ -35,6 +41,8 @@ elseif(UNIX)
 else()
     target_link_libraries(${PROJECT_NAME} setupapi)
 endif()
+# Make the headers available to any targets linking the library (e.g., serial_example, test, via FetchContent).
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 ## Uncomment for example
 add_executable(serial_example examples/serial_example.cc)
@@ -52,7 +60,7 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 ## Install headers
-install(FILES include/serial/serial.h include/serial/v8stdint.h
+install(FILES ${serial_HDRS}
     DESTINATION include/serial)
 
 ## Install CMake config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1)
 project(serial)
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(serial)
 
+option(CXX_SERIAL_EXAMPLES "Build the cxx-serial example targets" ON)
+option(CXX_SERIAL_TEST "Build the cxx-serial test targets" ON)
+option(CXX_SERIAL_INSTALL "Configure the cxx-serial install targets" ON)
+
 if(APPLE)
     find_library(IOKIT_LIBRARY IOKit)
     find_library(FOUNDATION_LIBRARY Foundation)
@@ -44,36 +48,38 @@ endif()
 # Make the headers available to any targets linking the library (e.g., serial_example, test, via FetchContent).
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
-## Uncomment for example
-add_executable(serial_example examples/serial_example.cc)
-add_dependencies(serial_example ${PROJECT_NAME})
-target_link_libraries(serial_example ${PROJECT_NAME})
+if(${CXX_SERIAL_EXAMPLES})
+    ## Example executable using cxx-serial
+    add_executable(serial_example examples/serial_example.cc)
+    add_dependencies(serial_example ${PROJECT_NAME})
+    target_link_libraries(serial_example ${PROJECT_NAME})
+endif()
 
-## Include headers
-include_directories(include)
+if(${CXX_SERIAL_INSTALL})
+    ## Install executable
+    install(TARGETS ${PROJECT_NAME}
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+    )
 
-## Install executable
-install(TARGETS ${PROJECT_NAME}
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-)
+    ## Install headers
+    install(FILES ${serial_HDRS}
+        DESTINATION include/serial)
 
-## Install headers
-install(FILES ${serial_HDRS}
-    DESTINATION include/serial)
+    ## Install CMake config
+    install(FILES cmake/serialConfig.cmake
+        DESTINATION share/serial/cmake)
 
-## Install CMake config
-install(FILES cmake/serialConfig.cmake
-    DESTINATION share/serial/cmake)
-
-
-## Install package.xml
-install(FILES package.xml
-    DESTINATION share/serial)
+    ## Install package.xml
+    install(FILES package.xml
+        DESTINATION share/serial)
+endif()
 
 ## Tests
-include(CTest)
-if(BUILD_TESTING)
-    add_subdirectory(tests)
+if(${CXX_SERIAL_TEST})
+    enable_testing()
+    if(BUILD_TESTING)
+        add_subdirectory(tests)
+    endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ Install:
 
     make install
 
+### Direct use in CMake Project
+
+```CMake
+include(FetchContent)
+set(CXX_SERIAL_EXAMPLES OFF)
+set(CXX_SERIAL_TEST OFF)
+set(CXX_SERIAL_INSTALL OFF)
+FetchContent_Declare(cxx_serial
+  GIT_REPOSITORY https://github.com/wjwwood/cxx_serial.git
+  GIT_TAG        f3d6e6cc9d8ee6b25575184d67a872b5d8d2fda9
+)
+FetchContent_MakeAvailable(cxx_serial)
+# ...
+target_link_libraries(${PROJECT_NAME} PRIVATE serial)
+```
+
 ### License
 
 [The MIT License](LICENSE)


### PR DESCRIPTION
Fixes #3 

This PR modifies CMakeLists.txt to make it easier for an independent project to add cxx_serial as a dependency via CMake's FetchContent.

The examples, tests, and install targets are all optional (default to ON).

Furthermore, I used some slightly more modern CMake syntax to mark the include files as the `serial` target's public includes, so any client target linking to the serial target gets the includes for free. This also allowed me to remove the `include` directory from the global include directories.

I did not re-run the tests nor did I test installing this project and linking to the installed version.